### PR TITLE
Dutch typos and clarifications

### DIFF
--- a/nederlands.tex
+++ b/nederlands.tex
@@ -5,73 +5,73 @@
 \renewcommand{\general}{
     \lettrine[lines=3]{E}{en} spel dat men in een minuut snapt, maar dat jarenlang blijft fascineren.
     Met twee spelers duurt een spel 20 minuten. Met drie of vier spelers duurt het 40 tot 90 minuten.
-    Er zijn geen dobbelstenen. Geschikt voor iedereen vanaf 5 Jaar.
-    In de doos: 4$\times$5 gekleurde figuren, 5 zwarte en 5 grijse blokkades en het spelbord.
+    Het spel is geschikt voor iedereen vanaf 5 Jaar en wordt zonder dobbelstenen gespeeld.
+    In de doos zitten 4$\times$5 gekleurde figuren, 5 zwarte blokkades, 5 grijze blokkades en het spelbord.
 }
 
 \renewcommand{\choosext}{Figuren}
 \renewcommand{\choosex}{
     Elke speler heeft een team van vijf figuren van een vorm naar keuze.
 
-    In elk team zit een rode, een blauwe, een witte, een groene en een gele figuur.
+    In elk team zit een rood, blauw, wit, groen en geel figuur.
 
-    Ze beginnen in de hoeken van de eigen kleur, en eindigen in de kruizingen van de eigen kleur, waar ze uit gaan.
+    Elk figuur begint in de hoek van de eigen kleur, en eindigt in de kruising van de eigen kleur, waar het van het bord verwijderd wordt.
 }
 
 \renewcommand{\setupt}{Opbouw}
 \renewcommand{\setup}{
-    Zet je figuren op de hoeken van dezelfde kleur, het witte figuur op de witte hoek, de gele figuur op de gele hoek, enz.
+    Zet je figuren op de hoeken van dezelfde kleur, het witte figuur op de witte hoek, het gele figuur op de gele hoek, enz.
     
-    Zet de zwarte blokkades op de gekleurde kruizingen in het midden.
+    Zet de zwarte blokkades op de gekleurde kruisingen in het midden.
 
-    Zet de grijze blokkades voor nu in het midden.
+    Zet de grijze blokkades voorlopig in het midden.
 }
 
 \renewcommand{\objectivet}{Doel van het spel}
 \renewcommand{\objective}{
-    Witte figuren moeten naar de witte kruizing, gele figuren naar de gele kruizing, enz.
-    Het doel is altijd de kruizing van dezelfde kleur tegenover het beginpunt.
+    Witte figuren moeten naar de witte kruising, gele figuren naar de gele kruising, enz.
+    Het doel is altijd de kruising van dezelfde kleur tegenover het beginpunt.
 
-    Wie het eerst \emph{drie} figuren naar hen doel krijgt, wint.
+    De winnaar is degene die het eerst \emph{drie} figuren uit het spel krijgt.
 }
 
 \renewcommand{\rulest}{Spelregels}
 \renewcommand{\rules}{
-    Zet een van je figuren op de ster of ring in een richting, zo ver als je wilt.
+    Verplaats een van je figuren in elke richting, zo ver als je wilt.
     
-    Je kan bij elke hoek of kruizing van richting veranderen zonder de zet te beeindigen.
+    Je kan bij elke hoek of kruising van richting veranderen zonder de zet te beëindigen.
 
-    Je kan nooit overspringen, niet over blokkades, en niet over andere figuren.
-
-    \myskip
-
-    Maar je mag de figuur wel \emph{tot op} een bezet veld zetten en slaan:
+    Je kan hierbij nooit over andere figuren springen, dus ook niet over blokkades.
 
     \myskip
 
-    Als je een zwarte blokkade slaat, mag je de blokkade op een ander vrij veld zetten. 
+    Maar je mag met je figuur wel slaan door het \emph{op} een bezet veld te zetten:
+
+    \myskip
+
+    Als je een zwarte blokkade slaat, mag je de blokkade naar een willekeurig vrij veld verplaatsen. 
 
     Als je een ander figuur slaat, ruil je van positie met dat figuur.
 
     \myskip
 
-    Je kan de posities van twee van je eigen figuren zo omruilen.
+    Je kan op deze manier dus ook twee van je eigen figuren van plek verwisselen.
 
-    Wanneer je naar een veld met meerdere figuren zet, moet je \emph{één} van de figuren slaan.
+    Wanneer je naar een veld met meerdere figuren zet, sla je maar \emph{één} van die figuren.
 
     \myskip 
  
-    Je mag niet twee keer achter elkaar dezelfde zet maken.
+    Je mag niet twee keer achter elkaar dezelfde zet doen.
 
     \myskip 
 
-    Een figuur dat zijn doel heeft berreikt is uit het spel. Deze wordt in het midden van het bord gezet. Je kan nu een van de grijze blokkades op een vrij veld van het bord zetten.
+    Een figuur dat zijn doel heeft bereikt gaat uit het spel. Deze wordt in het midden van het bord gezet. Je kan nu een van de grijze blokkades op een vrij veld van het bord zetten.
 
     Wanneer een van deze grijze blokkades wordt geslagen, wordt deze weer uit het spel gezet.
 
     \myskip 
 
-    Wanneer een andere speler je figuur op zijn doel heeft gezet, \emph{moet} je deze uit zetten met je volgende beurt.
+    Wanneer een andere speler een van jouw figuren naar zijn doel heeft verplaatst, \emph{moet} je deze verwijderen met je volgende beurt.
 
     \myskip
 

--- a/nederlands.tex
+++ b/nederlands.tex
@@ -67,7 +67,9 @@
 
     Een figuur dat zijn doel heeft bereikt gaat uit het spel. Deze wordt in het midden van het bord gezet. Je kan nu een van de grijze blokkades op een vrij veld van het bord zetten.
 
-    Wanneer een van deze grijze blokkades wordt geslagen, wordt deze weer uit het spel gezet.
+    Als er geen grijze blokkades meer in het midden staan, verplaats je een grijze blokkade die al op het bord staat.
+
+    Wanneer een grijze blokkade wordt geslagen, wordt deze weer uit het spel verwijderd en naar het midden verplaatst.
 
     \myskip 
 
@@ -75,6 +77,6 @@
 
     \myskip
 
-    De laatste ronde wordt tot het einde gespeeld.
-    % Wie het eerst     \emph{drie} van zijn figuren uit heeft, wint.
+    De laatste ronde gaat tot het einde door zodat iedereen evenveel zetten heeft gespeeld.
+    Als het meerdere spelers lukt om 3 figuren uit te spelen, is het gelijkspel. 
 }

--- a/nederlands.tex
+++ b/nederlands.tex
@@ -15,7 +15,7 @@
 
     In elk team zit een rood, blauw, wit, groen en geel figuur.
 
-    Elk figuur begint in de hoek van de eigen kleur, en eindigt in de kruising van de eigen kleur, waar het van het bord verwijderd wordt.
+    Elk figuur begint op de hoek van de eigen kleur, en eindigt op de kruising van de eigen kleur, waar het van het bord verwijderd wordt.
 }
 
 \renewcommand{\setupt}{Opbouw}
@@ -24,7 +24,7 @@
     
     Zet de zwarte blokkades op de gekleurde kruisingen in het midden.
 
-    Zet de grijze blokkades voorlopig in het midden.
+    Zet de grijze blokkades voorlopig in de open ruimte in het midden van het bord.
 }
 
 \renewcommand{\objectivet}{Doel van het spel}
@@ -37,7 +37,7 @@
 
 \renewcommand{\rulest}{Spelregels}
 \renewcommand{\rules}{
-    Verplaats een van je figuren in elke richting, zo ver als je wilt.
+    Verplaats per beurt een van je eigen figuren in elke richting, zo ver als je wilt.
     
     Je kan bij elke hoek of kruising van richting veranderen zonder de zet te beëindigen.
 
@@ -73,7 +73,7 @@
 
     \myskip 
 
-    Wanneer een andere speler een van jouw figuren naar zijn doel heeft verplaatst, \emph{moet} je deze verwijderen met je volgende beurt.
+    Wanneer een andere speler een van jouw figuren naar zijn doel heeft verplaatst, \emph{moet} je deze verwijderen in je volgende beurt.
 
     \myskip
 


### PR DESCRIPTION
The Dutch version had some typo's like kruizingen instead of kruisingen, but I also did some rewrites and clarifications, like changing "There are no dices." into "This game (...) is played without dices". 
